### PR TITLE
Ignore secrets that will be deleted after rendering

### DIFF
--- a/hooks/forbid_secrets.py
+++ b/hooks/forbid_secrets.py
@@ -6,27 +6,39 @@ import sys
 
 SECRET_REGEX = r"^kind:\ssecret"
 SOPS_REGEX = r"ENC.AES256"
+KUSTOMIZE_REGEX = r"^\$patch:\sdelete"
+
 
 def contains_secret(filename):
     with open(filename, mode="r") as file_checked:
         lines = file_checked.read()
-        kubernetes_secret = re.findall(SECRET_REGEX, lines, flags=re.IGNORECASE | re.MULTILINE)
+        kubernetes_secret = re.findall(
+            SECRET_REGEX, lines, flags=re.IGNORECASE | re.MULTILINE
+        )
         if kubernetes_secret:
-            sops_secret = re.findall(SOPS_REGEX, lines, flags=re.IGNORECASE | re.MULTILINE)
-            if not sops_secret:
+            ignore_secret = re.findall(
+                SOPS_REGEX, lines, flags=re.IGNORECASE | re.MULTILINE
+            ) or re.findall(KUSTOMIZE_REGEX, lines, flags=re.IGNORECASE | re.MULTILINE)
+            if not ignore_secret:
                 return True
     return False
 
+
 def main(argv=None):
     parser = argparse.ArgumentParser()
-    parser.add_argument('filenames', nargs='*', help='filenames to check')
+    parser.add_argument("filenames", nargs="*", help="filenames to check")
     args = parser.parse_args(argv)
     files_with_secrets = [f for f in args.filenames if contains_secret(f)]
     return_code = 0
     for file_with_secrets in files_with_secrets:
-        print('Unencrypted Kubernetes secret detected in file: {0}'.format(file_with_secrets))
+        print(
+            "Unencrypted Kubernetes secret detected in file: {0}".format(
+                file_with_secrets
+            )
+        )
         return_code = 1
     return return_code
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     sys.exit(main(sys.argv[1:]))

--- a/tests/secret-kustomize-pass.yaml
+++ b/tests/secret-kustomize-pass.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgres-secret
+$patch: delete

--- a/tests/secret-kustomize-pass.yml
+++ b/tests/secret-kustomize-pass.yml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mysql-secret
+$patch: delete


### PR DESCRIPTION
### Changes in this PR:

- I ran `python-black` on `hooks/forbid_secrets.py`
- `hooks/forbid_secrets.py` now ignores `kustomize` patches to delete a secret

### Example:

#### `kustomization.yaml`

```yaml
apiVersion: kustomize.config.k8s.io/v1beta1
kind: Kustomization
patchesStrategicMerge:
  - patches/example.yaml
```

#### `patches/example.yaml`

```yaml
apiVersion: v1
kind: Secret
metadata:
  name: mysql-secret
$patch: delete
```

#### Output from tests

```shell
$  python3 hooks/forbid_secrets.py tests/secret-fail.yaml
Unencrypted Kubernetes secret detected in file: tests/secret-fail.yaml
$  python3 hooks/forbid_secrets.py tests/secret-pass.yaml
$  echo $?
0
$  python3 hooks/forbid_secrets.py tests/secret-kustomize-pass.y*
$  python3 hooks/forbid_secrets.py tests/secret-kustomize-pass.yaml
$  echo $?
0
```